### PR TITLE
retrieval of any value from components property

### DIFF
--- a/OpenCage.Geocode/DictionaryExtensions.cs
+++ b/OpenCage.Geocode/DictionaryExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OpenCage.Geocode
+{
+    public static class DictionaryExtensions
+    {
+        public static TValue GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue = default(TValue))
+        {
+            if (dictionary == null) { throw new ArgumentNullException(nameof(dictionary)); }
+            if (key == null) { throw new ArgumentNullException(nameof(key)); }
+
+            TValue value;
+            return dictionary.TryGetValue(key, out value) ? value : defaultValue;
+        }
+    }
+}

--- a/OpenCage.Geocode/ResponseObjects/Location.cs
+++ b/OpenCage.Geocode/ResponseObjects/Location.cs
@@ -1,17 +1,48 @@
-﻿namespace OpenCage.Geocode
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace OpenCage.Geocode
 {
+    [DataContract]
     public class Location
     {
+        [DataMember(Name = "Annotations")]
         public Annotations Annotations { get; set; }
 
+        [DataMember(Name = "Formatted")]
         public string Formatted { get; set; }
 
-        public AddressComponent Components { get; set; }
+        [DataMember(Name = "Components")]
+        public Dictionary<string, string> ComponentsDictionary { get; set; }
 
+        public AddressComponent Components
+        {
+            get
+            {
+                return new AddressComponent
+                {
+                    BusStop = ComponentsDictionary.GetValueOrDefault("bus_stop"),
+                    City = ComponentsDictionary.GetValueOrDefault("city"),
+                    Country = ComponentsDictionary.GetValueOrDefault("country"),
+                    County = ComponentsDictionary.GetValueOrDefault("county"),
+                    CountryCode = ComponentsDictionary.GetValueOrDefault("country_code"),
+                    Postcode = ComponentsDictionary.GetValueOrDefault("postcode"),
+                    Road = ComponentsDictionary.GetValueOrDefault("road"),
+                    State = ComponentsDictionary.GetValueOrDefault("state"),
+                    StateDistrict = ComponentsDictionary.GetValueOrDefault("state_district"),
+                    Suburb = ComponentsDictionary.GetValueOrDefault("suburb"),
+                    Type = ComponentsDictionary.GetValueOrDefault("_type")
+                };
+            }
+        }
+
+        [DataMember(Name = "Geometry")]
         public Point Geometry { get; set; }
 
+        [DataMember(Name = "Bounds")]
         public Bounds Bounds { get; set; }
 
+        [DataMember(Name = "Confidence")]
         public int Confidence { get; set; }
     }
 }


### PR DESCRIPTION
Added possibility to retrieve any value which is present in components hashset.

As it turns out components property which is returned by opencage API in reality is hashset. We, on the other hand, treat it as strongly typed object. As a result, we're missing some of the data.

For example we can search for village and city property will be empty while village property will reflect willage name. 

Also, to make API backward compatible, I have left Components property as is, however it is now populated from `ComponentsDictionary`.

Have tested few scenarios and it works, however didn't tested every possible case.