### PR TITLE
Add ReverseGeocodeAsync method. Also fix near-zero coordinate ToString()

### DIFF
--- a/OpenCage.Geocode.sln
+++ b/OpenCage.Geocode.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{1A7DB7
 		Shared\Program.cs = Shared\Program.cs
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.NetCore", "Tests.NetCore\Tests.NetCore.csproj", "{D2485306-42C9-4991-95FE-0D095EC99BC3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Ad-Hoc|Any CPU = Ad-Hoc|Any CPU
@@ -102,6 +104,30 @@ Global
 		{39E0B352-6BE1-4624-8646-72107B8414EC}.Release|iPhone.Build.0 = Release|Any CPU
 		{39E0B352-6BE1-4624-8646-72107B8414EC}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{39E0B352-6BE1-4624-8646-72107B8414EC}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Ad-Hoc|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.AppStore|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.AppStore|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Release|iPhone.Build.0 = Release|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{D2485306-42C9-4991-95FE-0D095EC99BC3}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenCage.Geocode/Geocoder.cs
+++ b/OpenCage.Geocode/Geocoder.cs
@@ -1,8 +1,9 @@
-﻿namespace OpenCage.Geocode
+﻿using System.Threading.Tasks;
+
+namespace OpenCage.Geocode
 {
     using System;
     using System.Net;
-    using ServiceStack.Text;
     using ServiceStack;
 
     public class Geocoder : IGeocoder
@@ -72,13 +73,13 @@
             string language = "en",
             string countrycode = null,
             Bounds bounds = null,
-			bool abbrv = false,
-			int limit = 10,
-			int minConfidence = 0,
-			bool noAnnotations = false,
-			bool noDedupe = false,
-			bool noRecord = false,
-			bool addRequest = false)
+            bool abbrv = false,
+            int limit = 10,
+            int minConfidence = 0,
+            bool noAnnotations = false,
+            bool noDedupe = false,
+            bool noRecord = false,
+            bool addRequest = false)
         {
             var url = string.Format(Baseurl, WebUtility.UrlEncode(query), this.key, WebUtility.UrlEncode(language));
 
@@ -90,7 +91,7 @@
             {
                 url += "&countrycode=" + countrycode;
             }
-			AddCommonOptionalParameters(ref url, limit, minConfidence, noAnnotations, noDedupe, noRecord, abbrv, addRequest);
+            AddCommonOptionalParameters(ref url, limit, minConfidence, noAnnotations, noDedupe, noRecord, abbrv, addRequest);
 
             return this.GetResponse(url);
         }
@@ -109,68 +110,156 @@
         /// <param name="addRequest">When set to true the various request parameters are added to the response for ease of debugging.</param>
         /// <returns></returns>
         public GeocoderResponse ReverseGeocode(
-			double latitude, 
-			double longitude, 
-			string language = "en",
-			bool abbrv = false,
-			int limit = 10,
-			int minConfidence = 0,
-			bool noAnnotations = false,
-			bool noDedupe = false,
-			bool noRecord = false,
-			bool addRequest = false			
-			)
+            double latitude,
+            double longitude,
+            string language = "en",
+            bool abbrv = false,
+            int limit = 10,
+            int minConfidence = 0,
+            bool noAnnotations = false,
+            bool noDedupe = false,
+            bool noRecord = false,
+            bool addRequest = false
+            )
         {
-            var url = string.Format(Baseurl, latitude + "%2C" + longitude, this.key, WebUtility.UrlEncode(language));
-			AddCommonOptionalParameters(ref url, limit, minConfidence, noAnnotations, noDedupe, noRecord, abbrv, addRequest);
-			
-            return this.GetResponse(url);
+            var url = GetReverseGeocodeUrl(latitude, longitude, language, abbrv, limit, minConfidence, noAnnotations, noDedupe, noRecord, addRequest);
+            return GetResponse(url);
         }
 
-        private GeocoderResponse GetResponse(string url)
+        /// <summary>
+        /// Reverse geocoding given a latitude and longitude
+        /// </summary>
+        /// <param name="latitude">The latitude</param>
+        /// <param name="longitude">The longitude</param>
+        /// <param name="language">An IETF format language code (such as es for Spanish or pt-BR for Brazilian Portuguese).</param>
+        /// <param name="abbrv">When set to true we attempt to abbreviate and shorten the formatted string we return</param>
+        /// <param name="limit">How many results should be returned. Default is 10. Maximum is 100.</param>
+        /// <param name="minConfidence">An integer from 1-10. Only results with at least this confidence will be returned.</param>
+        /// <param name="noAnnotations">When set to true results will not contain annotations.</param>
+        /// <param name="noDedupe">	When set to true results will not be deduplicated.</param>
+        /// <param name="noRecord">When set to true the query contents are not logged. Please use if you have concerns about privacy and want us to have no record of your query.</param>
+        /// <param name="addRequest">When set to true the various request parameters are added to the response for ease of debugging.</param>
+        /// <returns></returns>
+        public async Task<GeocoderResponse> ReverseGeocodeAsync(
+            double latitude,
+            double longitude,
+            string language = "en",
+            bool abbrv = false,
+            int limit = 10,
+            int minConfidence = 0,
+            bool noAnnotations = false,
+            bool noDedupe = false,
+            bool noRecord = false,
+            bool addRequest = false
+        )
         {
-            string result = string.Empty;
+            var url = GetReverseGeocodeUrl(latitude, longitude, language, abbrv, limit, minConfidence, noAnnotations, noDedupe, noRecord, addRequest);
+            return await GetResponseAsync(url);
+        }
 
+        private string GetReverseGeocodeUrl(double latitude,
+            double longitude,
+            string language,
+            bool abbrv,
+            int limit,
+            int minConfidence,
+            bool noAnnotations,
+            bool noDedupe,
+            bool noRecord,
+            bool addRequest)
+        {
+            var url = GetReverseGeocodeUrl(latitude, longitude, language);
+            AddCommonOptionalParameters(ref url, limit, minConfidence, noAnnotations, noDedupe, noRecord, abbrv, addRequest);
+            return url;
+        }
+
+        protected string GetReverseGeocodeUrl(double latitude, double longitude, string language)
+        {
+            return string.Format(Baseurl, ToNonScientificString(latitude) + "%2C" + ToNonScientificString(longitude), key, WebUtility.UrlEncode(language));
+        }
+
+        protected static string ToNonScientificString(double d)
+        {
+            var s = d.ToString(DoubleFormat).TrimEnd('0');
+            return s.Length == 0 ? "0.0" : s;
+        }
+
+        private static readonly string DoubleFormat = "0." + new string('#', 339);
+
+        private async Task<GeocoderResponse> GetResponseAsync(string url)
+        {
             try
             {
-                result = url.GetJsonFromUrl();
+                var result = await url.GetJsonFromUrlAsync();
                 return result.FromJson<GeocoderResponse>();
             }
             catch (WebException webex)
             {
-                var response = webex.Response as HttpWebResponse;
+                var gcr = ProcessExceptionGeocoderResponse(webex);
 
-                // check if error can be returned as a http status
-                if (response != null)
+                if (gcr != null)
                 {
-
-                    var body = webex.GetResponseBody();
-                    try
-                    {
-                        var gcr = body.FromJson<GeocoderResponse>();
-                        switch ((int)response.StatusCode)
-                        {
-                            case 400:
-                                gcr.Status.Message = "Invalid request (bad request; a required parameter is missing; invalid coordinates))";
-                                break;
-                            case 402:
-                                gcr.Status.Message = "Valid request but quota exceeded (payment required)";
-                                break;
-                            case 403:
-                                gcr.Status.Message = "Invalid or missing api key (forbidden)";
-                                break;
-                            case 429:
-                                gcr.Status.Message = "Too many requests (too quickly, rate limiting)";
-                                break;
-
-                        }
-                        return gcr;
-                    }
-                    catch (Exception ex)
-                    {
-                        return new GeocoderResponse() { Status = new RequestStatus() { Code = (int)response.StatusCode, Message = ex.Message } };
-                    }
+                    return gcr;
                 }
+
+                throw;
+            }
+        }
+
+        private static GeocoderResponse ProcessExceptionGeocoderResponse(WebException webex)
+
+        {
+            // check if error can be returned as a http status
+            if (webex.Response is HttpWebResponse response)
+            {
+
+                var body = webex.GetResponseBody();
+                try
+                {
+                    var gcr = body.FromJson<GeocoderResponse>();
+                    switch ((int)response.StatusCode)
+                    {
+                        case 400:
+                            gcr.Status.Message = "Invalid request (bad request; a required parameter is missing; invalid coordinates))";
+                            break;
+                        case 402:
+                            gcr.Status.Message = "Valid request but quota exceeded (payment required)";
+                            break;
+                        case 403:
+                            gcr.Status.Message = "Invalid or missing api key (forbidden)";
+                            break;
+                        case 429:
+                            gcr.Status.Message = "Too many requests (too quickly, rate limiting)";
+                            break;
+
+                    }
+                    return gcr;
+                }
+                catch (Exception ex)
+                {
+                    return new GeocoderResponse { Status = new RequestStatus { Code = (int)response.StatusCode, Message = ex.Message } };
+                }
+            }
+
+            return null;
+        }
+
+        private GeocoderResponse GetResponse(string url)
+        {
+            try
+            {
+                var result = url.GetJsonFromUrl();
+                return result.FromJson<GeocoderResponse>();
+            }
+            catch (WebException webex)
+            {
+                var gcr = ProcessExceptionGeocoderResponse(webex);
+
+                if (gcr != null)
+                {
+                    return gcr;
+                }
+
                 throw;
             }
         }

--- a/Tests.NetCore/GetReverseGeocodeUrlTests.cs
+++ b/Tests.NetCore/GetReverseGeocodeUrlTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using OpenCage.Geocode;
+
+namespace Tests.NetCore
+{
+    public class GetReverseGeocodeUrlTests
+    {
+        private TestGeocoder geocoder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            geocoder = new TestGeocoder("the-key");
+        }
+
+        private class TestGeocoder : Geocoder
+        {
+            public string GetReverseGeocodeUrlPublic(double latitude, double longitude, string language)
+            {
+                return GetReverseGeocodeUrl(latitude, longitude, language);
+            }
+
+            public static string ToNonScientificStringPublic(double d)
+            {
+                return ToNonScientificString(d);
+            }
+
+            public TestGeocoder(string key) : base(key)
+            {
+            }
+        }
+
+        [Test]
+        public void WhenNearZero_ExpectCorrectUrl()
+        {
+            // Longitude of 0.000009 is converted to 9E-06 using Invariant ToString, but we need 0.000009
+            Assert.AreEqual("https://api.opencagedata.com/geocode/v1/json?q=57.231%2C0.000009&key=the-key&language=en", geocoder.GetReverseGeocodeUrlPublic(57.231d, 0.000009d, "en"));
+        }
+
+        [Test]
+        public void WhenNearZero_ExpectCorrectToString()
+        {
+            // Longitude of 0.000009 is converted to 9E-06 using Invariant ToString, but we need 0.000009
+            Assert.AreEqual("0.000009", TestGeocoder.ToNonScientificStringPublic(0.000009d));
+        }
+
+        [Test]
+        public void WhenZero_ExpectCorrectToString()
+        {
+            Assert.AreEqual("0.0", TestGeocoder.ToNonScientificStringPublic(0.0d));
+        }
+    }
+}

--- a/Tests.NetCore/Tests.NetCore.csproj
+++ b/Tests.NetCore/Tests.NetCore.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenCage.Geocode\OpenCage.Geocode.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Added async ReverseGeocodeAsync method.
Also added fix for reverse geocode of near-zero coordinate, e.g. longitude of 0.000009, which is converted to "9E-06" using standard ToString().
Refactored to share methods between async and non-async methods, also to allow testing of URL generation for near-zero coordinate.
Added test project and test method for near-zero longitude.